### PR TITLE
MINVOKER-233 Improve DefaultInvoker with a timeout. 

### DIFF
--- a/src/main/java/org/apache/maven/shared/invoker/DefaultInvoker.java
+++ b/src/main/java/org/apache/maven/shared/invoker/DefaultInvoker.java
@@ -39,6 +39,8 @@ public class DefaultInvoker
 
     public static final String ROLE_HINT = "default";
 
+    private static final int NO_TIMEOUT = 0;
+
     private static final InvokerLogger DEFAULT_LOGGER = new SystemOutLogger();
 
     private static final InvocationOutputHandler DEFAULT_OUTPUT_HANDLER = new SystemOutHandler();
@@ -60,6 +62,12 @@ public class DefaultInvoker
     private InvocationOutputHandler errorHandler = DEFAULT_OUTPUT_HANDLER;
 
     public InvocationResult execute( InvocationRequest request )
+            throws MavenInvocationException
+    {
+        return this.execute( request , NO_TIMEOUT );
+    }
+
+    public InvocationResult execute( InvocationRequest request, int timeoutInSeconds )
         throws MavenInvocationException
     {
         MavenCommandLineBuilder cliBuilder = new MavenCommandLineBuilder();
@@ -108,7 +116,7 @@ public class DefaultInvoker
 
         try
         {
-            int exitCode = executeCommandLine( cli, request );
+            int exitCode = executeCommandLine( cli, request, timeoutInSeconds );
 
             result.setExitCode( exitCode );
         }
@@ -120,7 +128,7 @@ public class DefaultInvoker
         return result;
     }
 
-    private int executeCommandLine( Commandline cli, InvocationRequest request )
+    private int executeCommandLine( Commandline cli, InvocationRequest request, int timeoutInSeconds )
         throws CommandLineException
     {
         int result = Integer.MIN_VALUE;
@@ -141,7 +149,7 @@ public class DefaultInvoker
                 getLogger().info( "Executing in batch mode. The configured input stream will be ignored." );
             }
 
-            result = CommandLineUtils.executeCommandLine( cli, outputHandler, errorHandler );
+            result = CommandLineUtils.executeCommandLine( cli, outputHandler, errorHandler, timeoutInSeconds );
         }
         else
         {
@@ -150,11 +158,12 @@ public class DefaultInvoker
                 getLogger().warn( "Maven will be executed in interactive mode"
                     + ", but no input stream has been configured for this MavenInvoker instance." );
 
-                result = CommandLineUtils.executeCommandLine( cli, outputHandler, errorHandler );
+                result = CommandLineUtils.executeCommandLine( cli, outputHandler, errorHandler, timeoutInSeconds );
             }
             else
             {
-                result = CommandLineUtils.executeCommandLine( cli, inputStream, outputHandler, errorHandler );
+                result = CommandLineUtils.executeCommandLine( cli, inputStream, outputHandler, errorHandler,
+                        timeoutInSeconds );
             }
         }
 

--- a/src/main/java/org/apache/maven/shared/invoker/Invoker.java
+++ b/src/main/java/org/apache/maven/shared/invoker/Invoker.java
@@ -48,6 +48,19 @@ public interface Invoker
         throws MavenInvocationException;
 
     /**
+     * Executes Maven using the parameters specified by the given invocation request. Parameters not specified by the
+     * invocation request will be derived from the state of this invoker instance. In case both the invoker instance and
+     * the invocation request provide a value for a particular option, the value from the invocation request dominates.
+     *
+     * @param request The invocation request to execute, must not be <code>null</code>.
+     * @param timeoutInSeconds If a value > 0 is specified, the goal might be interrupted after the timeout is reached.
+     * @return The result of the Maven invocation, never <code>null</code>.
+     * @throws MavenInvocationException
+     */
+    InvocationResult execute( InvocationRequest request, int timeoutInSeconds )
+            throws MavenInvocationException;
+
+    /**
      * Gets the path to the base directory of the local repository to use for the Maven invocation.
      * 
      * @return The path to the base directory of the local repository or <code>null</code> to use the location from

--- a/src/test/java/org/apache/maven/shared/invoker/DefaultInvokerTest.java
+++ b/src/test/java/org/apache/maven/shared/invoker/DefaultInvokerTest.java
@@ -88,6 +88,32 @@ public class DefaultInvokerTest
     }
 
     @Test
+    public void testBuildShouldTimeout()
+            throws IOException, MavenInvocationException, URISyntaxException
+    {
+        File basedir = getBasedirForBuild();
+
+        Invoker invoker = newInvoker();
+
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setBaseDirectory( basedir );
+        request.setDebug( true );
+        request.setGoals( Arrays.asList( "clean", "package" ) );
+
+        if ( !System.getProperty( "java.version" ).startsWith( "1." ) )
+        {
+            Properties properties = new Properties();
+            properties.put( "maven.compiler.source", "1.6" );
+            properties.put( "maven.compiler.target", "1.6" );
+            request.setProperties( properties );
+        }
+
+        InvocationResult result = invoker.execute( request, 10 );
+
+        assertEquals( 1, result.getExitCode() );
+    }
+
+    @Test
     public void testSpacePom()
         throws Exception
     {

--- a/src/test/resources/test-build-should-timeout/pom.xml
+++ b/src/test/resources/test-build-should-timeout/pom.xml
@@ -1,0 +1,34 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.shared.invoker</groupId>
+  <artifactId>test-build-should-timeout</artifactId>
+  <packaging>jar</packaging>
+  <version>1</version>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/test-build-should-timeout/src/main/java/org/apache/maven/shared/invoker/App.java
+++ b/src/test/resources/test-build-should-timeout/src/main/java/org/apache/maven/shared/invoker/App.java
@@ -1,0 +1,32 @@
+package org.apache.maven.shared.invoker;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/test/resources/test-build-should-timeout/src/test/java/org/apache/maven/shared/invoker/AppTest.java
+++ b/src/test/resources/test-build-should-timeout/src/test/java/org/apache/maven/shared/invoker/AppTest.java
@@ -1,0 +1,61 @@
+package org.apache.maven.shared.invoker;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Not ending test
+     */
+    public void testApp()
+    {
+        while (true) {
+            Thread.sleep(1);
+        }
+
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR aims at fixing MINVOKER-233

The purpose is to add a timeout in `DefaultInvoker` as it's already handled by `CommandLineUtils.executeCommandLine`. 
The default behaviour won't change.
