### PR TITLE
remove --no-module-directories from javadoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,6 @@ under the License.
           <version>3.3.1</version>
           <configuration>
             <detectLinks>false</detectLinks>
-            <additionalJOption>--no-module-directories</additionalJOption>
           </configuration>
         </plugin>
         <plugin>
@@ -213,6 +212,6 @@ under the License.
         </plugins>
       </build>
     </profile>
-    
+
   </profiles>
 </project>


### PR DESCRIPTION
it is not available for jdk 8
it was removed in jdk 13