### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/shared/invoker/MavenCommandLineBuilder.java
+++ b/src/main/java/org/apache/maven/shared/invoker/MavenCommandLineBuilder.java
@@ -461,7 +461,7 @@ public class MavenCommandLineBuilder {
      */
     protected void setThreads(InvocationRequest request, Commandline cli) {
         String threads = request.getThreads();
-        if (StringUtils.isNotEmpty(threads)) {
+        if (threads != null && !threads.isEmpty()) {
             cli.createArg().setValue("-T");
             cli.createArg().setValue(threads);
         }

--- a/src/test/java/org/apache/maven/shared/invoker/DefaultInvokerTest.java
+++ b/src/test/java/org/apache/maven/shared/invoker/DefaultInvokerTest.java
@@ -278,7 +278,7 @@ public class DefaultInvokerTest {
     private File findLocalRepo() {
         String basedir = System.getProperty("maven.repo.local", "");
 
-        if (StringUtils.isNotEmpty(basedir)) {
+        if (basedir != null && !basedir.isEmpty()) {
             return new File(basedir);
         }
 


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu