### PR TITLE
Removed InvocationRequest setGoals(List<String> goals)@deprecated 

### DIFF
--- a/src/main/java/org/apache/maven/shared/invoker/InvocationRequest.java
+++ b/src/main/java/org/apache/maven/shared/invoker/InvocationRequest.java
@@ -603,9 +603,7 @@ public interface InvocationRequest {
      *
      * @param goals The goals for the Maven invocation, may be <code>null</code> to execute the POMs default goal.
      * @return This invocation request.
-     * @deprecated simply {@link #addArg(String)} or {@link #addArgs(Collection)} should be used
      */
-    @Deprecated
     InvocationRequest setGoals(List<String> goals);
 
     /**


### PR DESCRIPTION
Removed @deprecated because addArg method is not a replacement for setGoals method when using archetype:generate command

