### PR TITLE
Support Maven PowerShell launcher hosts

### DIFF
--- a/src/main/java/org/apache/maven/shared/invoker/MavenCommandLineBuilder.java
+++ b/src/main/java/org/apache/maven/shared/invoker/MavenCommandLineBuilder.java
@@ -37,6 +37,9 @@ import org.apache.maven.shared.utils.cli.Commandline;
  */
 public class MavenCommandLineBuilder {
 
+    /** Set by Maven's PowerShell launcher to identify the host for nested Maven invocations. */
+    static final String MAVEN_POWERSHELL_EXECUTABLE = "MAVEN_POWERSHELL_EXECUTABLE";
+
     private static final InvokerLogger DEFAULT_LOGGER = new SystemOutLogger();
 
     private InvokerLogger logger = DEFAULT_LOGGER;
@@ -69,7 +72,7 @@ public class MavenCommandLineBuilder {
         checkRequiredState();
 
         setupMavenExecutable(request);
-        cli.setExecutable(mavenExecutable.getAbsolutePath());
+        configureMavenExecutable(cli);
 
         // handling for OS-level envars
         setShellEnvironment(request, cli);
@@ -103,6 +106,33 @@ public class MavenCommandLineBuilder {
         setArgs(request, cli);
 
         return cli;
+    }
+
+    private void configureMavenExecutable(Commandline cli) throws CommandLineConfigurationException {
+        if (isPowerShellScript(mavenExecutable)) {
+            String powerShellExecutable = getPowerShellExecutable();
+            if (powerShellExecutable == null) {
+                throw new CommandLineConfigurationException("Cannot execute Maven PowerShell script: '"
+                        + mavenExecutable + "'. The " + MAVEN_POWERSHELL_EXECUTABLE
+                        + " environment variable is not set.");
+            }
+
+            cli.setExecutable(powerShellExecutable);
+            cli.createArg().setValue("-NoProfile");
+            cli.createArg().setValue("-File");
+            cli.createArg().setValue(mavenExecutable.getAbsolutePath());
+        } else {
+            cli.setExecutable(mavenExecutable.getAbsolutePath());
+        }
+    }
+
+    private boolean isPowerShellScript(File executable) {
+        return StringUtils.endsWithIgnoreCase(executable.getName(), ".ps1");
+    }
+
+    String getPowerShellExecutable() {
+        String executable = System.getenv(MAVEN_POWERSHELL_EXECUTABLE);
+        return StringUtils.isNotBlank(executable) ? executable : null;
     }
 
     /**
@@ -542,12 +572,15 @@ public class MavenCommandLineBuilder {
     }
 
     private File detectMavenExecutablePerOs(File baseDirectory, String executable) {
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            File executableFile = new File(baseDirectory, executable + ".ps1");
+        File executableFile;
+        if (getPowerShellExecutable() != null) {
+            executableFile = new File(baseDirectory, executable + ".ps1");
             if (executableFile.isFile()) {
                 return executableFile;
             }
+        }
 
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             executableFile = new File(baseDirectory, executable + ".cmd");
             if (executableFile.isFile()) {
                 return executableFile;
@@ -559,7 +592,7 @@ public class MavenCommandLineBuilder {
             }
         }
 
-        File executableFile = new File(baseDirectory, executable);
+        executableFile = new File(baseDirectory, executable);
         if (executableFile.isFile()) {
             return executableFile;
         }

--- a/src/test/java/org/apache/maven/shared/invoker/MavenCommandLineBuilderTest.java
+++ b/src/test/java/org/apache/maven/shared/invoker/MavenCommandLineBuilderTest.java
@@ -242,8 +242,10 @@ class MavenCommandLineBuilderTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void shouldExecutePowerShellScriptThroughInheritedPowerShellHost() throws Exception {
-        File baseDirectory = Files.createDirectories(temporaryFolder.resolve("project")).toFile();
-        File mavenHome = Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
+        File baseDirectory =
+                Files.createDirectories(temporaryFolder.resolve("project")).toFile();
+        File mavenHome =
+                Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
         File powerShellExecutable = Files.createDirectories(temporaryFolder.resolve("PowerShell home with spaces"))
                 .resolve("pwsh")
                 .toFile();
@@ -259,7 +261,8 @@ class MavenCommandLineBuilderTest {
         }
         assertTrue(powerShellExecutable.setExecutable(true));
 
-        File outputFile = temporaryFolder.resolve("PowerShell output with spaces").toFile();
+        File outputFile =
+                temporaryFolder.resolve("PowerShell output with spaces").toFile();
         File mavenScript = temporaryFolder.resolve("mvn.ps1").toFile();
         try (FileWriter writer = new FileWriter(mavenScript)) {
             writer.write("printf '%s' \"$2\" > \"$1\"\n");
@@ -281,9 +284,12 @@ class MavenCommandLineBuilderTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void shouldExecutePowerShellScriptOnWindows() throws Exception {
-        File baseDirectory = Files.createDirectories(temporaryFolder.resolve("project")).toFile();
-        File mavenHome = Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
-        File outputFile = temporaryFolder.resolve("PowerShell output with spaces").toFile();
+        File baseDirectory =
+                Files.createDirectories(temporaryFolder.resolve("project")).toFile();
+        File mavenHome =
+                Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
+        File outputFile =
+                temporaryFolder.resolve("PowerShell output with spaces").toFile();
         File mavenScript = temporaryFolder.resolve("mvn.ps1").toFile();
         try (FileWriter writer = new FileWriter(mavenScript)) {
             writer.write("param([string] $OutputFile, [string] $Value)\n"
@@ -307,8 +313,10 @@ class MavenCommandLineBuilderTest {
 
     @Test
     void shouldRejectExplicitPowerShellScriptWithoutInheritedPowerShellHost() throws Exception {
-        File baseDirectory = Files.createDirectories(temporaryFolder.resolve("project")).toFile();
-        File mavenHome = Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
+        File baseDirectory =
+                Files.createDirectories(temporaryFolder.resolve("project")).toFile();
+        File mavenHome =
+                Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
         File mavenScript = createDummyFile(temporaryFolder.toFile(), "mvn.ps1").getCanonicalFile();
         mclb = new TestMavenCommandLineBuilder(null);
 

--- a/src/test/java/org/apache/maven/shared/invoker/MavenCommandLineBuilderTest.java
+++ b/src/test/java/org/apache/maven/shared/invoker/MavenCommandLineBuilderTest.java
@@ -37,6 +37,7 @@ import org.apache.maven.shared.utils.cli.Commandline;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -205,8 +206,7 @@ class MavenCommandLineBuilderTest {
     }
 
     @Test
-    @EnabledOnOs(OS.WINDOWS)
-    void shouldFindDummyPS1MavenExecutable() throws Exception {
+    void shouldFindDummyPS1MavenExecutableWhenPowerShellHostIsAvailable() throws Exception {
         File dummyMavenHomeBin = Files.createDirectories(temporaryFolder
                         .resolve("invoker-tests")
                         .resolve("dummy-maven-home")
@@ -214,10 +214,112 @@ class MavenCommandLineBuilderTest {
                 .toFile();
 
         File check = createDummyFile(dummyMavenHomeBin, "mvn.ps1");
+        mclb = new TestMavenCommandLineBuilder("powershell.exe");
         mclb.setMavenHome(dummyMavenHomeBin.getParentFile());
         mclb.setupMavenExecutable(newRequest());
 
         assertEquals(check.getCanonicalPath(), mclb.getMavenExecutable().getCanonicalPath());
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void shouldUseCmdWhenPowerShellHostIsUnavailable() throws Exception {
+        File dummyMavenHomeBin = Files.createDirectories(temporaryFolder
+                        .resolve("invoker-tests")
+                        .resolve("dummy-maven-home")
+                        .resolve("bin"))
+                .toFile();
+
+        createDummyFile(dummyMavenHomeBin, "mvn.ps1");
+        File check = createDummyFile(dummyMavenHomeBin, "mvn.cmd");
+        mclb = new TestMavenCommandLineBuilder(null);
+        mclb.setMavenHome(dummyMavenHomeBin.getParentFile());
+        mclb.setupMavenExecutable(newRequest());
+
+        assertEquals(check.getCanonicalPath(), mclb.getMavenExecutable().getCanonicalPath());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void shouldExecutePowerShellScriptThroughInheritedPowerShellHost() throws Exception {
+        File baseDirectory = Files.createDirectories(temporaryFolder.resolve("project")).toFile();
+        File mavenHome = Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
+        File powerShellExecutable = Files.createDirectories(temporaryFolder.resolve("PowerShell home with spaces"))
+                .resolve("pwsh")
+                .toFile();
+        try (FileWriter writer = new FileWriter(powerShellExecutable)) {
+            writer.write("#!/bin/sh\n"
+                    + "test \"$1\" = '-NoProfile' || exit 91\n"
+                    + "shift\n"
+                    + "test \"$1\" = '-File' || exit 92\n"
+                    + "shift\n"
+                    + "script=$1\n"
+                    + "shift\n"
+                    + "exec /bin/sh \"$script\" \"$@\"\n");
+        }
+        assertTrue(powerShellExecutable.setExecutable(true));
+
+        File outputFile = temporaryFolder.resolve("PowerShell output with spaces").toFile();
+        File mavenScript = temporaryFolder.resolve("mvn.ps1").toFile();
+        try (FileWriter writer = new FileWriter(mavenScript)) {
+            writer.write("printf '%s' \"$2\" > \"$1\"\n");
+        }
+
+        mclb = new TestMavenCommandLineBuilder(powerShellExecutable.getAbsolutePath());
+        Commandline commandline = mclb.build(newRequest()
+                .setBaseDirectory(baseDirectory)
+                .setMavenHome(mavenHome)
+                .setMavenExecutable(mavenScript)
+                .addArg(outputFile.getAbsolutePath())
+                .addArg("argument with spaces"));
+
+        Process process = commandline.execute();
+        assertEquals(0, process.waitFor());
+        assertEquals("argument with spaces", new String(Files.readAllBytes(outputFile.toPath()), "UTF-8"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void shouldExecutePowerShellScriptOnWindows() throws Exception {
+        File baseDirectory = Files.createDirectories(temporaryFolder.resolve("project")).toFile();
+        File mavenHome = Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
+        File outputFile = temporaryFolder.resolve("PowerShell output with spaces").toFile();
+        File mavenScript = temporaryFolder.resolve("mvn.ps1").toFile();
+        try (FileWriter writer = new FileWriter(mavenScript)) {
+            writer.write("param([string] $OutputFile, [string] $Value)\n"
+                    + "[IO.File]::WriteAllText($OutputFile, $Value)\n");
+        }
+
+        mclb = new TestMavenCommandLineBuilder("powershell.exe");
+        Commandline commandline = mclb.build(newRequest()
+                .setBaseDirectory(baseDirectory)
+                .setMavenHome(mavenHome)
+                .setMavenExecutable(mavenScript)
+                .addArg(outputFile.getAbsolutePath())
+                .addArg("argument with spaces & special character"));
+
+        Process process = commandline.execute();
+        assertEquals(0, process.waitFor());
+        assertEquals(
+                "argument with spaces & special character",
+                new String(Files.readAllBytes(outputFile.toPath()), "UTF-8"));
+    }
+
+    @Test
+    void shouldRejectExplicitPowerShellScriptWithoutInheritedPowerShellHost() throws Exception {
+        File baseDirectory = Files.createDirectories(temporaryFolder.resolve("project")).toFile();
+        File mavenHome = Files.createDirectories(temporaryFolder.resolve("maven-home")).toFile();
+        File mavenScript = createDummyFile(temporaryFolder.toFile(), "mvn.ps1").getCanonicalFile();
+        mclb = new TestMavenCommandLineBuilder(null);
+
+        CommandLineConfigurationException exception = assertThrows(
+                CommandLineConfigurationException.class,
+                () -> mclb.build(newRequest()
+                        .setBaseDirectory(baseDirectory)
+                        .setMavenHome(mavenHome)
+                        .setMavenExecutable(mavenScript)));
+
+        assertTrue(exception.getMessage().contains(MavenCommandLineBuilder.MAVEN_POWERSHELL_EXECUTABLE));
     }
 
     @Test
@@ -926,5 +1028,18 @@ class MavenCommandLineBuilderTest {
 
     private InvocationRequest newRequest() {
         return new DefaultInvocationRequest();
+    }
+
+    private static class TestMavenCommandLineBuilder extends MavenCommandLineBuilder {
+        private final String powerShellExecutable;
+
+        TestMavenCommandLineBuilder(String powerShellExecutable) {
+            this.powerShellExecutable = powerShellExecutable;
+        }
+
+        @Override
+        String getPowerShellExecutable() {
+            return powerShellExecutable;
+        }
     }
 }


### PR DESCRIPTION
This library is used by maven-invoker-plugin. When the new PowerShell scripts from https://github.com/apache/maven/pull/12541 are present, it chooses to run them via `cmd.exe` via `.ps1` extension association. This does not work reliably, especially on the GitHub CI nodes. This patch fixes that. This needs to be fixed and released, then maven-invoker-plugin can be released and only then can the PowerShell scripts be safely merged and released.

## Summary

- execute a Maven `.ps1` launcher through the PowerShell host advertised by `MAVEN_POWERSHELL_EXECUTABLE`
- select `mvn.cmd` on Windows when no PowerShell host is available
- reject an explicitly selected `.ps1` launcher when no host is known

## Why

This is the companion change required by [apache/maven#12541](https://github.com/apache/maven/pull/12541), which adds PowerShell launchers to Maven 4.x distributions.

Maven Invoker currently prefers `mvn.ps1` over `mvn.cmd` on Windows and passes it to `cmd.exe`. That relies on the system `.ps1` file association instead of invoking a PowerShell host. On GitHub's Windows runners the association opens Notepad, the nested Maven process never starts, and Maven Invoker waits indefinitely.

The Maven 4.x launcher publishes the PowerShell executable used to start it in `MAVEN_POWERSHELL_EXECUTABLE`. This change consumes that contract for nested Maven invocations.

## Testing

- `env JAVA_HOME=/opt/jdks/latest-8 /opt/maven/latest/bin/mvn -B -V verify`
- 113 tests run, 0 failures, 0 errors, 3 expected platform skips

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
